### PR TITLE
Fix Lancer-Class Pursuit Craft size

### DIFF
--- a/data/ships.js
+++ b/data/ships.js
@@ -2708,7 +2708,7 @@
       "Rotate Arc",
       "Target Lock"
     ],
-    "size": "small",
+    "size": "large",
     "attack": 3,
     "agility": 2,
     "hull": 7,


### PR DESCRIPTION
Lancer class pursuit craft should be large instead of small