### PR TITLE
Tie-fighters can now be used by Rebels, because of Sabine's Tie-Fighter.

### DIFF
--- a/data/ships.js
+++ b/data/ships.js
@@ -246,7 +246,8 @@
   {
     "name": "TIE Fighter",
     "faction": [
-      "Galactic Empire"
+      "Galactic Empire",
+      "Rebel Alliance"
     ],
     "attack": 2,
     "agility": 3,


### PR DESCRIPTION
I believe the Tie-fighter entry in ships.js should include the rebel faction, now that Sabine's Tie Fighter exists?

Thanks for your consideration.