### PR TITLE
Fix: Incorrect actions for Lancer-craft Pursuit Craft

### DIFF
--- a/data/ships.js
+++ b/data/ships.js
@@ -2745,7 +2745,7 @@
       "Scum and Villainy"
     ],
     "actions": [
-      "Boost",
+      "Focus",
       "Evade",
       "Rotate Arc",
       "Target Lock"


### PR DESCRIPTION
`Boost` should be `Focus`.