### PR TITLE
Remove Node 5 from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
   - "6"
-  - "5"


### PR DESCRIPTION
There really isn't any need to run the tests on multiple Node versions.