### PR TITLE
Fix XWS name for black eight squadron pilot

### DIFF
--- a/data/pilots.js
+++ b/data/pilots.js
@@ -2384,7 +2384,7 @@
     ],
     "image": "pilots/Galactic Empire/TIE Punisher/black-eight-squadron-pilot.png",
     "faction": "Galactic Empire",
-    "xws": "blackeightsquadronpilot"
+    "xws": "blackeightsqpilot"
   },
   {
     "name": "Moralo Eval",


### PR DESCRIPTION
According to https://github.com/elistevens/xws-spec/blob/master/dist/xws_pilots.json#L834
The TIE Punisher pilot "Black Eight Sq. Pilot" should have the xws name blackeightsqpilot.  I believe this is what is causing https://github.com/Mu0n/HWpopup/issues/75