### PR TITLE
Fix: Optimise image unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "ajv": "^4.10.0",
     "ajv-merge-patch": "^2.1.0",
+    "glob": "^7.1.2",
     "jest": "^20.0.4",
     "moment": "^2.17.1",
     "release-it": "^2.3.1"

--- a/tests/integrity.test.js
+++ b/tests/integrity.test.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var glob = require('glob');
 
 var Data = require("./data");
 var moment = require("moment");
@@ -71,6 +71,7 @@ describe("All data", function() {
 
   describe("that has an image file path", function() {
     test("should have a matching image file in the images directory", function() {
+      var allImages = glob.sync("images/**/*");
       var errors = [];
       var modelData;
 
@@ -80,14 +81,14 @@ describe("All data", function() {
             for (var i = 0; i < Data[dataKey].length; i++) {
               modelData = Data[dataKey][i];
 
-              if (modelData.image && !fs.existsSync("images/" +  modelData.image)) {
+              if (modelData.image && allImages.indexOf(`images/${modelData.image}`) === -1) {
                   errors.push(
                     utils.buildDataHeader(Data, dataKey, i) +
                     ": file 'images/" + modelData.image + "' was not found."
                   )
               }
 
-              if (modelData.thumb && !fs.existsSync("images/" + modelData.thumb)) {
+              if (modelData.thumb && allImages.indexOf(`images/${modelData.thumb}`) === -1) {
                   errors.push(
                     utils.buildDataHeader(Data, dataKey, i) +
                     ": file 'images/" + modelData.thumb + "' was not found."

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,6 +1018,17 @@ glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^9.0.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -1740,7 +1751,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-minimatch@^3.0.2, minimatch@^3.0.3:
+minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:


### PR DESCRIPTION
Don't read the filesystem for each image, but get a list of all images once and then check each image in the list.