### PR TITLE
New: Ordered dials for huge ships

### DIFF
--- a/data/ships.js
+++ b/data/ships.js
@@ -1088,7 +1088,17 @@
     ],
     "size": "huge",
     "xws": "gr75mediumtransport",
-    "id": 12
+    "id": 12,
+    "dial": [
+      "1BW2E",
+      "1FW3E",
+      "1NW2E",
+      "2BW1E",
+      "2FW2E",
+      "2NW1E",
+      "3FW1E",
+      "4FW"
+    ]
   },
   {
     "name": "Z-95 Headhunter",
@@ -1532,7 +1542,16 @@
     ],
     "size": "huge",
     "xws": "cr90corvettefore",
-    "id": 17
+    "id": 17,
+    "dial": [
+      "1BW3E",
+      "1NW3E",
+      "2BW2E",
+      "2FW3E",
+      "2NW2E",
+      "3FW2E",
+      "4FW1E"
+    ]
   },
   {
     "name": "CR90 Corvette (Aft)",
@@ -1634,7 +1653,16 @@
     ],
     "size": "huge",
     "xws": "cr90corvetteaft",
-    "id": 18
+    "id": 18,
+    "dial": [
+      "1BW3E",
+      "1NW3E",
+      "2BW2E",
+      "2FW3E",
+      "2NW2E",
+      "3FW2E",
+      "4FW1E"
+    ]
   },
   {
     "name": "YT-2400",
@@ -2155,7 +2183,17 @@
     ],
     "size": "huge",
     "xws": "raiderclasscorvettefore",
-    "id": 24
+    "id": 24,
+    "dial": [
+      "1BW3E",
+      "1FW3E",
+      "1NW3E",
+      "2BW2E",
+      "2FW3E",
+      "2NW2E",
+      "3FW2E",
+      "4FW1E"
+    ]
   },
   {
     "name": "Raider-class Corvette (Aft)",
@@ -2257,7 +2295,17 @@
     ],
     "size": "huge",
     "xws": "raiderclasscorvetteaft",
-    "id": 25
+    "id": 25,
+    "dial": [
+      "1BW3E",
+      "1FW3E",
+      "1NW3E",
+      "2BW2E",
+      "2FW3E",
+      "2NW2E",
+      "3FW2E",
+      "4FW1E"
+    ]
   },
   {
     "name": "YV-666",
@@ -3238,7 +3286,17 @@
       ]
     ],
     "xws": "gozanticlasscruiser",
-    "id": 37
+    "id": 37,
+    "dial": [
+      "1BW2E",
+      "1FW3E",
+      "1NW2E",
+      "2BW1E",
+      "2FW2E",
+      "2NW1E",
+      "3FW1E",
+      "4FW1E"
+    ]
   },
   {
     "name": "ARC-170",
@@ -3915,7 +3973,17 @@
         0
       ]
     ],
-    "id": 46
+    "id": 46,
+    "dial": [
+      "1BW2E",
+      "1FW3E",
+      "1NW2E",
+      "2BW1E",
+      "2FW2E",
+      "2NW1E",
+      "3FW2E",
+      "4FW1E"
+    ]
   },
   {
     "name": "Auzituck Gunship",

--- a/schemas/ships.json
+++ b/schemas/ships.json
@@ -74,12 +74,12 @@
         },
         "dial": {
           "type": "array",
-          "description": "This array is a representation of the ship's maneuver dial.\n\nEach item in this array references a maneuver's speed, bearing and difficulty in the following format: [speed][bearing][difficulty]\n\nThe bearing is indicated with a single character:\n\tT = Turn Left\n\tY = Turn Right\n\tB = Bank Left\n\tN = Bank Right\n\tF = Straight\n\tK = Koiogran Turn\n\tR = Tallon Roll Right\n\tE = Tallon Roll Left\n\tL = Segnor's Loop Left\n\tP = Segnor's Loop Right\n\tA = Reverse Bank Left\n\tD = Reverse Bank Right\n\tS = Reverse Straight\n\tO = Stationary",
+          "description": "This array is a representation of the ship's maneuver dial.\n\nEach item in this array references a maneuver's speed, bearing and difficulty in the following format: [speed][bearing][difficulty]\n\nThe bearing is indicated with a single character:\n\tT = Turn Left\n\tY = Turn Right\n\tB = Bank Left\n\tN = Bank Right\n\tF = Straight\n\tK = Koiogran Turn\n\tR = Tallon Roll Right\n\tE = Tallon Roll Left\n\tL = Segnor's Loop Left\n\tP = Segnor's Loop Right\n\tA = Reverse Bank Left\n\tD = Reverse Bank Right\n\tS = Reverse Straight\n\tO = Stationary\n\nIf a maneuver causes the ship to gain Energy the amount will be specified after the maneuver's difficulty followed by the letter E.",
           "uniqueItems": true,
           "items": {
             "type": "string",
             "description": "A maneuver on the ship's dial",
-            "pattern": "^[0-5][ERTYOPASDFKLBN][WGR]$"
+            "pattern": "^[0-5][ERTYOPASDFKLBN][WGR]([1-3]E)?$"
           }
         }
       },


### PR DESCRIPTION
If a maneuver causes the ship to gain energy it will be appended to the maneuver code as `#E` where `#` is the amount of energy gained.

Example: A white 1 forward maneuver that generates 2 energy would be `1FW2E`.

@Mu0n @mrmurphm Will this work for you for huge ships?