### PR TITLE
Added TIE Aggressor to Lightweight Frame

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -3440,6 +3440,7 @@
     "ship": [
       "TIE Adv. Prototype",
       "TIE Advanced",
+      "TIE Aggressor",
       "TIE Bomber",
       "TIE Defender",
       "TIE Fighter",


### PR DESCRIPTION
TIE Aggressor was missing from the allowed ships on Lightweight Frame.