### PR TITLE
Fix: Update TIE-only cards

### DIFF
--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -3439,18 +3439,12 @@
     "points": 2,
     "slot": "Modification",
     "ship": [
-      "TIE Adv. Prototype",
-      "TIE Advanced",
       "TIE Aggressor",
       "TIE Bomber",
-      "TIE Defender",
-      "TIE Fighter",
-      "TIE Interceptor",
       "TIE Phantom",
       "TIE Punisher",
-      "TIE Silencer",
+      "TIE Reaper",
       "TIE Striker",
-      "TIE/fo Fighter",
       "TIE/sf Fighter"
     ],
     "id": 296

--- a/data/upgrades.js
+++ b/data/upgrades.js
@@ -2176,6 +2176,7 @@
       "TIE Interceptor",
       "TIE Phantom",
       "TIE Punisher",
+      "TIE Reaper",
       "TIE Silencer",
       "TIE Striker",
       "TIE/fo Fighter",

--- a/tests/lightweight-frame.test.js
+++ b/tests/lightweight-frame.test.js
@@ -1,0 +1,13 @@
+const Data = require("./data");
+
+it('Lightweight Frame should work on all TIE ships that have agility <3', () => {
+  const lwfUpgrade = Data.upgrades.find(u => u.id === 296);
+  expect(lwfUpgrade.name).toEqual('Lightweight Frame');
+
+  const tieShips = Data.ships
+    .filter(s => s.name.match(/TIE/) && s.agility < 3)
+    .map(s => s.name)
+    .sort();
+
+  expect(lwfUpgrade.ship).toEqual(tieShips);
+});

--- a/tests/twin-ion-engine.test.js
+++ b/tests/twin-ion-engine.test.js
@@ -1,0 +1,13 @@
+const Data = require("./data");
+
+it('Twin Ion Engine Mk. II should work on all TIE ships', () => {
+  const twinIonUpgrade = Data.upgrades.find(u => u.id === 190);
+  expect(twinIonUpgrade.name).toEqual('Twin Ion Engine Mk. II');
+
+  const tieShips = Data.ships
+    .filter(s => s.name.match(/TIE/))
+    .map(s => s.name)
+    .sort();
+
+  expect(twinIonUpgrade.ship).toEqual(tieShips);
+});


### PR DESCRIPTION
This fixes the `ship` field for the _TIE_-only cards **Lightweight Frame** and **Twin Ion Engine Mk. II**, and adds unit tests to make sure we don't forget to add any new _TIE_ ships that are released in the future.